### PR TITLE
Add starter boilerplate modules

### DIFF
--- a/backtest/backtester.py
+++ b/backtest/backtester.py
@@ -1,0 +1,18 @@
+from strategies.base import BaseStrategy
+
+
+class Backtester:
+    """Very simple backtesting engine."""
+
+    def __init__(self, strategy: BaseStrategy):
+        self.strategy = strategy
+        self.trades = []
+
+    def run(self, prices: list[float]):
+        for price in prices:
+            self.strategy.on_data(price)
+            if self.strategy.should_buy():
+                self.trades.append(("buy", price))
+            elif self.strategy.should_sell():
+                self.trades.append(("sell", price))
+        return self.trades

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,5 @@
+api_key: "YOUR_API_KEY"
+secret_key: "YOUR_SECRET_KEY"
+uri_prefix: "https://api.exchange.com"
+private_ws_uri: "wss://ws.exchange.com/private"
+reconnect_interval: 5

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -1,0 +1,6 @@
+from typing import Dict
+
+
+def display_order(order: Dict):
+    """Simple console dashboard output for an executed order."""
+    print(f"Executed order: {order}")

--- a/engine/bot_engine.py
+++ b/engine/bot_engine.py
@@ -1,0 +1,22 @@
+from strategies.base import BaseStrategy
+from execution.order_manager import OrderManager
+from risk.risk_manager import RiskManager
+
+
+class BotEngine:
+    """Orchestrates strategy signals and order execution."""
+
+    def __init__(self, strategy: BaseStrategy, order_manager: OrderManager, risk_manager: RiskManager):
+        self.strategy = strategy
+        self.order_manager = order_manager
+        self.risk_manager = risk_manager
+        self.balance = 1.0  # pretend account balance
+
+    def on_price_update(self, price: float) -> None:
+        self.strategy.on_data(price)
+        if self.strategy.should_buy():
+            qty = self.risk_manager.size_position(self.balance, price)
+            self.order_manager.place_order("BUY", "BTCUSDT", qty, price)
+        elif self.strategy.should_sell():
+            qty = self.risk_manager.size_position(self.balance, price)
+            self.order_manager.place_order("SELL", "BTCUSDT", qty, price)

--- a/engine/regime_detector.py
+++ b/engine/regime_detector.py
@@ -1,0 +1,10 @@
+from typing import List
+
+
+class RegimeDetector:
+    """Detects market regime based on price data."""
+
+    def detect(self, prices: List[float]) -> str:
+        if len(prices) < 2:
+            return "unknown"
+        return "trend" if prices[-1] > prices[0] else "mean_revert"

--- a/engine/strategy_selector.py
+++ b/engine/strategy_selector.py
@@ -1,0 +1,13 @@
+from strategies.base import BaseStrategy
+
+
+class StrategySelector:
+    """Selects which strategy to run based on market regime."""
+
+    def __init__(self, strategies: dict[str, BaseStrategy]):
+        self.strategies = strategies
+        self.active: BaseStrategy | None = None
+
+    def select(self, regime: str) -> BaseStrategy:
+        self.active = self.strategies.get(regime, next(iter(self.strategies.values())))
+        return self.active

--- a/execution/broker_api.py
+++ b/execution/broker_api.py
@@ -1,0 +1,10 @@
+class BrokerAPI:
+    """Abstract broker API used by the bot."""
+
+    def buy(self, symbol: str, qty: float, price: float | None = None):
+        """Place a buy order."""
+        raise NotImplementedError
+
+    def sell(self, symbol: str, qty: float, price: float | None = None):
+        """Place a sell order."""
+        raise NotImplementedError

--- a/execution/order_manager.py
+++ b/execution/order_manager.py
@@ -1,0 +1,21 @@
+from typing import Any, Dict
+
+from .broker_api import BrokerAPI
+
+
+class OrderManager:
+    """Basic order manager that forwards orders to the broker."""
+
+    def __init__(self, broker: BrokerAPI):
+        self.broker = broker
+        self.orders: list[Dict[str, Any]] = []
+
+    def place_order(self, side: str, symbol: str, qty: float, price: float | None = None) -> Dict[str, Any]:
+        if side.upper() == "BUY":
+            order = self.broker.buy(symbol, qty, price)
+        elif side.upper() == "SELL":
+            order = self.broker.sell(symbol, qty, price)
+        else:
+            raise ValueError("side must be BUY or SELL")
+        self.orders.append(order)
+        return order

--- a/main.py
+++ b/main.py
@@ -1,0 +1,35 @@
+from execution.broker_api import BrokerAPI
+from execution.order_manager import OrderManager
+from engine.bot_engine import BotEngine
+from risk.risk_manager import RiskManager
+from strategies.ema_crossover import EMACrossoverStrategy
+
+
+class DummyBroker(BrokerAPI):
+    """A very naive broker implementation for demonstration."""
+
+    def buy(self, symbol: str, qty: float, price: float | None = None):
+        order = {"side": "BUY", "symbol": symbol, "qty": qty, "price": price}
+        print(f"Buying: {order}")
+        return order
+
+    def sell(self, symbol: str, qty: float, price: float | None = None):
+        order = {"side": "SELL", "symbol": symbol, "qty": qty, "price": price}
+        print(f"Selling: {order}")
+        return order
+
+
+def run_demo():
+    strategy = EMACrossoverStrategy()
+    broker = DummyBroker()
+    order_manager = OrderManager(broker)
+    risk_manager = RiskManager()
+    engine = BotEngine(strategy, order_manager, risk_manager)
+
+    prices = [100, 101, 102, 103, 102, 101, 104, 105, 104]
+    for price in prices:
+        engine.on_price_update(price)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/risk/risk_manager.py
+++ b/risk/risk_manager.py
@@ -1,0 +1,9 @@
+class RiskManager:
+    """Basic position sizing and risk checks."""
+
+    def __init__(self, max_position: float = 1.0):
+        self.max_position = max_position
+
+    def size_position(self, balance: float, price: float) -> float:
+        qty = balance / price
+        return min(qty, self.max_position)

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,0 +1,17 @@
+class BaseStrategy:
+    """Base class for trading strategies."""
+
+    def __init__(self, name: str = "Base"):
+        self.name = name
+
+    def on_data(self, price: float) -> None:
+        """Receive new price data."""
+        raise NotImplementedError
+
+    def should_buy(self) -> bool:
+        """Return True if a buy signal is generated."""
+        return False
+
+    def should_sell(self) -> bool:
+        """Return True if a sell signal is generated."""
+        return False

--- a/strategies/breakout.py
+++ b/strategies/breakout.py
@@ -1,0 +1,22 @@
+from collections import deque
+from typing import Deque
+
+from .base import BaseStrategy
+
+
+class BreakoutStrategy(BaseStrategy):
+    """Channel breakout strategy."""
+
+    def __init__(self, window: int = 20):
+        super().__init__(name="Breakout")
+        self.window = window
+        self.prices: Deque[float] = deque(maxlen=window)
+
+    def on_data(self, price: float) -> None:
+        self.prices.append(price)
+
+    def should_buy(self) -> bool:
+        return len(self.prices) == self.window and self.prices[-1] == max(self.prices)
+
+    def should_sell(self) -> bool:
+        return len(self.prices) == self.window and self.prices[-1] == min(self.prices)

--- a/strategies/ema_crossover.py
+++ b/strategies/ema_crossover.py
@@ -1,0 +1,34 @@
+from collections import deque
+from typing import Deque
+
+from .base import BaseStrategy
+from utils.indicators import exponential_moving_average
+
+
+class EMACrossoverStrategy(BaseStrategy):
+    """Simple EMA crossover strategy."""
+
+    def __init__(self, fast: int = 12, slow: int = 26):
+        super().__init__(name="EMA Crossover")
+        self.fast = fast
+        self.slow = slow
+        self.prices: Deque[float] = deque(maxlen=slow)
+        self.fast_ema = None
+        self.slow_ema = None
+
+    def on_data(self, price: float) -> None:
+        self.prices.append(price)
+        if len(self.prices) >= self.slow:
+            price_list = list(self.prices)
+            self.fast_ema = exponential_moving_average(price_list, self.fast)
+            self.slow_ema = exponential_moving_average(price_list, self.slow)
+
+    def should_buy(self) -> bool:
+        if self.fast_ema is None or self.slow_ema is None:
+            return False
+        return self.fast_ema > self.slow_ema
+
+    def should_sell(self) -> bool:
+        if self.fast_ema is None or self.slow_ema is None:
+            return False
+        return self.fast_ema < self.slow_ema

--- a/utils/indicators.py
+++ b/utils/indicators.py
@@ -1,0 +1,19 @@
+from typing import List, Optional
+
+
+def simple_moving_average(prices: List[float], period: int) -> Optional[float]:
+    """Calculate simple moving average."""
+    if len(prices) < period:
+        return None
+    return sum(prices[-period:]) / period
+
+
+def exponential_moving_average(prices: List[float], period: int) -> Optional[float]:
+    """Calculate exponential moving average."""
+    if len(prices) < period:
+        return None
+    ema = prices[0]
+    alpha = 2 / (period + 1)
+    for price in prices[1:]:
+        ema = alpha * price + (1 - alpha) * ema
+    return ema

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,10 @@
+import logging
+
+
+def get_logger(name: str = "bot", level: int = logging.INFO) -> logging.Logger:
+    """Configure and return a logger."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    return logging.getLogger(name)


### PR DESCRIPTION
## Summary
- add basic strategy abstractions and sample strategies
- implement simple order execution, risk management, and engine
- add utilities for logging and indicators
- provide minimal backtester, dashboard, and configuration
- create demonstration `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68690fa68a04832a971f4977011ee42c