### PR TITLE
Add Bitunix broker wrapper and update demo

### DIFF
--- a/api/broker_api.py
+++ b/api/broker_api.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict
+
+from .config import Config
+from .open_api_http_future_private import OpenApiHttpFuturePrivate
+
+
+class BrokerAPI:
+    """Wrapper around Bitunix HTTP API for order execution."""
+
+    def __init__(self, config_path: str = "api/config.yaml") -> None:
+        self.config = Config(config_path)
+        self.client = OpenApiHttpFuturePrivate(self.config)
+
+    def market_order(self, symbol: str, side: str, qty: float) -> Dict[str, Any]:
+        """Place a market order."""
+        return self.client.place_order(
+            symbol=symbol,
+            side=side.upper(),
+            order_type="MARKET",
+            qty=str(qty),
+        )
+
+    def limit_order(self, symbol: str, side: str, qty: float, price: float) -> Dict[str, Any]:
+        """Place a limit order."""
+        return self.client.place_order(
+            symbol=symbol,
+            side=side.upper(),
+            order_type="LIMIT",
+            qty=str(qty),
+            price=str(price),
+        )

--- a/execution/order_manager.py
+++ b/execution/order_manager.py
@@ -1,21 +1,36 @@
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-from .broker_api import BrokerAPI
+from api.broker_api import BrokerAPI
+from utils.trade_logger import TradeLogger
 
 
 class OrderManager:
-    """Basic order manager that forwards orders to the broker."""
+    """Send orders through BrokerAPI and log them."""
 
-    def __init__(self, broker: BrokerAPI):
+    def __init__(self, broker: BrokerAPI, logger: Optional[TradeLogger] = None) -> None:
         self.broker = broker
+        self.logger = logger
         self.orders: list[Dict[str, Any]] = []
 
-    def place_order(self, side: str, symbol: str, qty: float, price: float | None = None) -> Dict[str, Any]:
-        if side.upper() == "BUY":
-            order = self.broker.buy(symbol, qty, price)
-        elif side.upper() == "SELL":
-            order = self.broker.sell(symbol, qty, price)
+    def place_order(
+        self,
+        side: str,
+        symbol: str,
+        qty: float,
+        price: float | None = None,
+        order_type: str = "market",
+    ) -> Dict[str, Any]:
+        side = side.lower()
+        order_type = order_type.lower()
+        if order_type == "market":
+            order = self.broker.market_order(symbol, side, qty)
+        elif order_type == "limit":
+            if price is None:
+                raise ValueError("price required for limit order")
+            order = self.broker.limit_order(symbol, side, qty, price)
         else:
-            raise ValueError("side must be BUY or SELL")
+            raise ValueError("order_type must be 'market' or 'limit'")
         self.orders.append(order)
+        if self.logger:
+            self.logger.log_trade(order)
         return order

--- a/risk/risk_manager.py
+++ b/risk/risk_manager.py
@@ -1,17 +1,55 @@
-class RiskManager:
-    """Position sizing and basic risk checks."""
+from typing import Iterable, Tuple, Optional
 
-    def __init__(self, max_position: float = 1.0, risk_percent: float = 0.01):
+from utils.indicators import atr
+
+
+class RiskManager:
+    """Position sizing using ATR-based stop loss and take profit."""
+
+    def __init__(
+        self,
+        max_position: float = 1.0,
+        risk_percent: float = 0.01,
+        atr_period: int = 14,
+        sl_mult: float = 1.0,
+        tp_mult: float = 2.0,
+    ) -> None:
         self.max_position = max_position
         self.risk_percent = risk_percent
+        self.atr_period = atr_period
+        self.sl_mult = sl_mult
+        self.tp_mult = tp_mult
 
-    def size_position(self, balance: float, price: float, stop_price: float | None = None) -> float:
-        if stop_price:
-            risk_per_unit = abs(price - stop_price)
-            if risk_per_unit == 0:
-                qty = 0
-            else:
-                qty = (balance * self.risk_percent) / risk_per_unit
+    def size_position(
+        self,
+        balance: float,
+        price: float,
+        stop_price: float | None = None,
+    ) -> float:
+        """Return position size based on risk percent."""
+        if stop_price is None:
+            qty = balance / price if price > 0 else 0.0
         else:
-            qty = balance / price
+            risk_per_unit = abs(price - stop_price)
+            if risk_per_unit <= 0:
+                return 0.0
+            qty = (balance * self.risk_percent) / risk_per_unit
         return min(qty, self.max_position)
+
+    def atr_levels(
+        self,
+        highs: Iterable[float],
+        lows: Iterable[float],
+        closes: Iterable[float],
+    ) -> Optional[Tuple[float, float]]:
+        """Calculate stop loss and take profit based on ATR."""
+        highs_list = list(highs)
+        lows_list = list(lows)
+        closes_list = list(closes)
+        atr_val = atr(highs_list, lows_list, closes_list, self.atr_period)
+        if atr_val is None or not closes_list:
+            return None
+        price = closes_list[-1]
+        sl = price - atr_val * self.sl_mult
+        tp = price + atr_val * self.tp_mult
+        return sl, tp

--- a/utils/trade_logger.py
+++ b/utils/trade_logger.py
@@ -1,0 +1,42 @@
+import sqlite3
+from typing import Any, Dict, Optional
+
+
+class TradeLogger:
+    """Log executed trades to a SQLite database."""
+
+    def __init__(self, db_path: str = "journal/trade_log.db") -> None:
+        self.db_path = db_path
+        self.conn = sqlite3.connect(self.db_path)
+        self._create_table()
+
+    def _create_table(self) -> None:
+        self.conn.execute(
+            """CREATE TABLE IF NOT EXISTS trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT,
+            side TEXT,
+            symbol TEXT,
+            qty REAL,
+            price REAL
+        )"""
+        )
+        self.conn.commit()
+
+    def log_trade(self, trade: Dict[str, Any]) -> None:
+        """Insert a trade record into the database."""
+        self.conn.execute(
+            "INSERT INTO trades (timestamp, side, symbol, qty, price) VALUES (?, ?, ?, ?, ?)",
+            (
+                trade.get("timestamp")
+                or trade.get("datetime"),
+                trade.get("side"),
+                trade.get("symbol"),
+                float(trade.get("amount") or trade.get("qty")),
+                float(trade.get("price")) if trade.get("price") is not None else None,
+            ),
+        )
+        self.conn.commit()
+
+    def close(self) -> None:
+        self.conn.close()


### PR DESCRIPTION
## Summary
- refactor `api/broker_api` to call Bitunix HTTP API
- adjust `main.py` to use this broker wrapper

## Testing
- `python -m py_compile risk/risk_manager.py execution/order_manager.py api/broker_api.py utils/trade_logger.py main.py`
- `python main.py | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68693251db54832a8f1f5e78c074a5b9