### PR TITLE
Add adaptive strategy management

### DIFF
--- a/analysis/replay_engine.py
+++ b/analysis/replay_engine.py
@@ -1,0 +1,32 @@
+from typing import Dict, List, Tuple
+
+from backtest.backtester import Backtester
+from engine.strategy_selector import StrategySelector
+
+
+class ReplayEngine:
+    """Simulate historical trades and update strategy scores."""
+
+    def __init__(self, selector: StrategySelector) -> None:
+        self.selector = selector
+
+    def _pnl(self, trades: List[Tuple[str, float]], prices: List[float]) -> float:
+        position = 0
+        cash = 0.0
+        for side, price in trades:
+            if side == "buy":
+                cash -= price
+                position += 1
+            elif side == "sell":
+                cash += price
+                position -= 1
+        if position:
+            cash += position * prices[-1]
+        return cash
+
+    def run(self, prices: List[float]) -> Dict[str, float]:
+        for name, strategy in self.selector.strategies.items():
+            trades = Backtester(strategy).run(prices)
+            reward = self._pnl(trades, prices)
+            self.selector.score_manager.update_score(name, reward)
+        return self.selector.score_manager.get_all()

--- a/engine/regime_detector.py
+++ b/engine/regime_detector.py
@@ -1,10 +1,29 @@
-from typing import List
+from collections import deque
+from typing import Deque, Dict
+
+from utils.indicators import atr
 
 
 class RegimeDetector:
-    """Detects market regime based on price data."""
+    """Classify regime based on ATR and volatility bands."""
 
-    def detect(self, prices: List[float]) -> str:
-        if len(prices) < 2:
+    def __init__(self, atr_period: int = 14, band_mult: float = 1.5) -> None:
+        self.atr_period = atr_period
+        self.band_mult = band_mult
+        self.highs: Deque[float] = deque(maxlen=atr_period * 2)
+        self.lows: Deque[float] = deque(maxlen=atr_period * 2)
+        self.closes: Deque[float] = deque(maxlen=atr_period * 2)
+
+    def on_data(self, candle: Dict[str, float]) -> None:
+        self.highs.append(candle["high"])
+        self.lows.append(candle["low"])
+        self.closes.append(candle["close"])
+
+    def detect(self) -> str:
+        if len(self.closes) < self.atr_period + 1:
             return "unknown"
-        return "trend" if prices[-1] > prices[0] else "mean_revert"
+        atr_val = atr(list(self.highs), list(self.lows), list(self.closes), self.atr_period)
+        if atr_val is None:
+            return "unknown"
+        band = max(self.highs) - min(self.lows)
+        return "trending" if band > atr_val * self.band_mult else "ranging"

--- a/engine/score_manager.py
+++ b/engine/score_manager.py
@@ -1,0 +1,23 @@
+from collections import defaultdict
+from typing import Dict
+
+
+class ScoreManager:
+    """Store and update strategy scores using exponential decay."""
+
+    def __init__(self, decay: float = 0.9) -> None:
+        self.decay = decay
+        self.scores: Dict[str, float] = defaultdict(float)
+
+    def update_score(self, name: str, reward: float) -> float:
+        """Update and return the EMA-weighted score."""
+        current = self.scores.get(name, 0.0)
+        new_score = current * self.decay + reward
+        self.scores[name] = new_score
+        return new_score
+
+    def get_score(self, name: str) -> float:
+        return self.scores.get(name, 0.0)
+
+    def get_all(self) -> Dict[str, float]:
+        return dict(self.scores)

--- a/engine/strategy_selector.py
+++ b/engine/strategy_selector.py
@@ -1,13 +1,33 @@
+import random
+from typing import Dict
+
 from strategies.base import BaseStrategy
+from .score_manager import ScoreManager
 
 
 class StrategySelector:
-    """Selects which strategy to run based on market regime."""
+    """Pick strategies using an epsilon-greedy MAB approach."""
 
-    def __init__(self, strategies: dict[str, BaseStrategy]):
+    def __init__(
+        self,
+        strategies: Dict[str, BaseStrategy],
+        score_manager: ScoreManager,
+        epsilon: float = 0.1,
+    ) -> None:
         self.strategies = strategies
+        self.score_manager = score_manager
+        self.epsilon = epsilon
         self.active: BaseStrategy | None = None
 
-    def select(self, regime: str) -> BaseStrategy:
-        self.active = self.strategies.get(regime, next(iter(self.strategies.values())))
+    def select(self) -> BaseStrategy:
+        if not self.strategies:
+            raise ValueError("no strategies available")
+        if random.random() < self.epsilon:
+            self.active = random.choice(list(self.strategies.values()))
+        else:
+            scores = {
+                name: self.score_manager.get_score(name) for name in self.strategies
+            }
+            best = max(scores, key=scores.get)
+            self.active = self.strategies[best]
         return self.active

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -1,0 +1,34 @@
+"""Simple mean reversion trading strategy."""
+
+from collections import deque
+from typing import Deque
+
+from .base import BaseStrategy
+from utils.indicators import simple_moving_average
+
+
+class MeanReversionStrategy(BaseStrategy):
+    """Buy when price dips below the moving average and sell on rallies."""
+
+    def __init__(self, window: int = 10, threshold: float = 0.01) -> None:
+        super().__init__(name="Mean Reversion")
+        self.window = window
+        self.threshold = threshold
+        self.prices: Deque[float] = deque(maxlen=window)
+
+    def on_data(self, price: float) -> None:  # type: ignore[override]
+        self.prices.append(price)
+
+    def generate_signal(self) -> str:  # type: ignore[override]
+        if len(self.prices) < self.window:
+            return "hold"
+        sma = simple_moving_average(list(self.prices), self.window)
+        if sma is None:
+            return "hold"
+        last_price = self.prices[-1]
+        if last_price < sma * (1 - self.threshold):
+            return "buy"
+        if last_price > sma * (1 + self.threshold):
+            return "sell"
+        return "hold"
+


### PR DESCRIPTION
## Summary
- score strategies using `ScoreManager`
- update strategy selection with epsilon‑greedy bandit logic
- classify regime via ATR in `RegimeDetector`
- run historical replay and update scores
- extend demo to show strategy selection in action

## Testing
- `python -m py_compile engine/score_manager.py engine/strategy_selector.py engine/regime_detector.py analysis/replay_engine.py strategies/mean_reversion.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_686937803f50832a8c37f2b92b020ed5