### PR TITLE
Implement multi-symbol market data fetching

### DIFF
--- a/api/binance_api.py
+++ b/api/binance_api.py
@@ -1,0 +1,7 @@
+import ccxt
+
+
+def fetch_ohlcv(symbol: str, timeframe: str = "1h", limit: int = 100) -> list:
+    exchange = ccxt.binance()
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe, limit=limit)
+    return ohlcv

--- a/api/bitunix_broker.py
+++ b/api/bitunix_broker.py
@@ -1,0 +1,10 @@
+import requests
+
+def fetch_ohlcv(symbol: str, timeframe: str = "1h", limit: int = 100) -> list:
+    """Fetch OHLCV from Bitunix API and return as list of [timestamp, open, high, low, close, volume]"""
+    url = f"https://api.bitunix.com/api/v1/market/candles?symbol={symbol}&interval={timeframe}&limit={limit}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise ValueError(f"Bitunix API error: {response.text}")
+    data = response.json().get('data', [])
+    return data[::-1]  # oldest to newest

--- a/data/market_data_collector.py
+++ b/data/market_data_collector.py
@@ -1,34 +1,77 @@
-from typing import Any, List
-
-from api.config import Config
-from api.open_api_http_future_public import OpenApiHttpFuturePublic
-from utils.logger import get_logger
+import pandas as pd
+import os
+from api import bitunix_broker, binance_api
+from typing import Dict, Iterable, Tuple, Union
 
 
 class MarketDataCollector:
-    """Fetch OHLCV data from Bitunix using the HTTP API."""
+    def __init__(self, fallback: bool = True):
+        self.fallback = fallback
 
-    def __init__(
-        self,
-        symbol: str,
-        timeframe: str = "1m",
-        limit: int = 500,
-        config_path: str = "api/config.yaml",
-    ) -> None:
-        self.client = OpenApiHttpFuturePublic(Config(config_path))
-        self.symbol = symbol
-        self.timeframe = timeframe
-        self.limit = limit
-        self.logger = get_logger(self.__class__.__name__)
+    def _get_single_ohlcv(
+        self, symbol: str, timeframe: str, limit: int = 100, save: bool = True
+    ) -> pd.DataFrame:
+        try:
+            data = bitunix_broker.fetch_ohlcv(symbol, timeframe, limit)
+        except Exception as e:
+            print(f"Bitunix failed: {e}")
+            if not self.fallback:
+                raise
+            data = binance_api.fetch_ohlcv(symbol, timeframe, limit)
 
-    def fetch_ohlcv(self) -> List[Any]:
-        """Return raw OHLCV candles."""
-        self.logger.info(
-            "Fetching OHLCV for %s timeframe %s limit %d",
-            self.symbol,
-            self.timeframe,
-            self.limit,
+        df = pd.DataFrame(
+            data,
+            columns=["timestamp", "open", "high", "low", "close", "volume"],
         )
-        data = self.client.get_kline(self.symbol, self.timeframe, self.limit)
-        self.logger.info("Fetched %d candles", len(data))
-        return data
+        df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+
+        if save:
+            os.makedirs("data/raw", exist_ok=True)
+            df.to_csv(f"data/raw/{symbol}_{timeframe}.csv", index=False)
+
+        return df
+
+    def get_ohlcv(
+        self,
+        symbol: Union[str, Iterable[str]],
+        timeframe: Union[str, Iterable[str]],
+        limit: int = 100,
+        save: bool = True,
+    ) -> Union[pd.DataFrame, Dict[Tuple[str, str], pd.DataFrame]]:
+        if isinstance(symbol, str) and isinstance(timeframe, str):
+            return self._get_single_ohlcv(symbol, timeframe, limit, save)
+
+        symbols = [symbol] if isinstance(symbol, str) else list(symbol)
+        timeframes = [timeframe] if isinstance(timeframe, str) else list(timeframe)
+
+        results: Dict[Tuple[str, str], pd.DataFrame] = {}
+        for sym in symbols:
+            for tf in timeframes:
+                results[(sym, tf)] = self._get_single_ohlcv(sym, tf, limit, save)
+        return results
+
+
+def load_cached_or_fetch(
+    symbol: Union[str, Iterable[str]],
+    timeframe: Union[str, Iterable[str]],
+    limit: int = 100,
+) -> Union[pd.DataFrame, Dict[Tuple[str, str], pd.DataFrame]]:
+    if isinstance(symbol, str) and isinstance(timeframe, str):
+        path = f"data/raw/{symbol}_{timeframe}.csv"
+        if os.path.exists(path):
+            return pd.read_csv(path, parse_dates=["timestamp"])
+        return MarketDataCollector().get_ohlcv(symbol, timeframe, limit)
+
+    symbols = [symbol] if isinstance(symbol, str) else list(symbol)
+    timeframes = [timeframe] if isinstance(timeframe, str) else list(timeframe)
+    results: Dict[Tuple[str, str], pd.DataFrame] = {}
+    collector = MarketDataCollector()
+    for sym in symbols:
+        for tf in timeframes:
+            path = f"data/raw/{sym}_{tf}.csv"
+            if os.path.exists(path):
+                results[(sym, tf)] = pd.read_csv(path, parse_dates=["timestamp"])
+            else:
+                results[(sym, tf)] = collector.get_ohlcv(sym, tf, limit)
+    return results
+

--- a/main.py
+++ b/main.py
@@ -70,9 +70,10 @@ def run_demo(use_real_api: bool = False, use_collector: bool = True) -> None:
     risk_manager = RiskManager()
 
     if use_collector:
-        collector = MarketDataCollector("ETHUSDT", timeframe="5m", limit=20)
-        candles = collector.fetch_ohlcv()
-        logger.info("Fetched %d candles", len(candles))
+        collector = MarketDataCollector()
+        df = collector.get_ohlcv("ETHUSDT", "5m", 20)
+        candles = df.to_dict("records")
+        logger.info("Fetched %d candles", len(df))
         logger.info("First candle: %s", candles[0] if candles else "no data")
     else:
         candles = [[0, p, p, p, p, 1] for p in [100, 101, 102, 103, 102, 101, 104, 105, 104]]

--- a/test_market_data_collector.py
+++ b/test_market_data_collector.py
@@ -1,0 +1,13 @@
+from data.market_data_collector import MarketDataCollector
+
+collector = MarketDataCollector()
+
+# Single symbol/timeframe
+single = collector.get_ohlcv(symbol="BTCUSDT", timeframe="1h", limit=100)
+print(single.head())
+
+# Multiple symbols and timeframes
+multi = collector.get_ohlcv(symbol=["BTCUSDT", "ETHUSDT"], timeframe=["1h", "4h"], limit=10)
+for key, df in multi.items():
+    print(key, df.head())
+


### PR DESCRIPTION
## Summary
- extend MarketDataCollector with a private _get_single_ohlcv helper
- allow fetching OHLCV for multiple symbols and timeframes
- update load_cached_or_fetch accordingly
- expand example test script for multi-symbol usage

## Testing
- `python -m py_compile api/bitunix_broker.py api/binance_api.py data/market_data_collector.py main.py test_market_data_collector.py`
- `python test_market_data_collector.py` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686944f46b38832aa03828cadf577bfa