### PR TITLE
Add market data collector with caching

### DIFF
--- a/data/fetch_api.py
+++ b/data/fetch_api.py
@@ -1,0 +1,27 @@
+import requests
+from typing import List, Dict, Any
+
+BASE_URL = "https://fapi.bitunix.com/api/v1/futures/market/kline"
+
+
+def get_klines(symbol: str, interval: str, limit: int = 100,
+               start_time: int | None = None,
+               end_time: int | None = None) -> List[Dict[str, Any]]:
+    """Fetch OHLCV data from Bitunix public API."""
+    params = {
+        "symbol": symbol,
+        "interval": interval,
+        "limit": limit,
+        "type": "LAST_PRICE",
+    }
+    if start_time is not None:
+        params["startTime"] = start_time
+    if end_time is not None:
+        params["endTime"] = end_time
+
+    response = requests.get(BASE_URL, params=params, timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("code") != 0:
+        raise RuntimeError(payload.get("msg", "API error"))
+    return payload.get("data", [])

--- a/data/market_data_collector.py
+++ b/data/market_data_collector.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Dict, Any
+
+import pandas as pd
+
+from .fetch_api import get_klines
+
+RAW_DATA_DIR = Path(__file__).resolve().parent / "raw"
+RAW_DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def fetch_market_data(symbol: str, interval: str, limit: int = 100,
+                      force_refresh: bool = False) -> pd.DataFrame:
+    """Fetch OHLCV market data and cache the result.
+
+    Parameters
+    ----------
+    symbol : str
+        Trading pair symbol, e.g. ``"BTCUSDT"``.
+    interval : str
+        Kline interval, e.g. ``"1m"`` or ``"1h"``.
+    limit : int, optional
+        Number of data points to fetch, by default ``100``.
+    force_refresh : bool, optional
+        Ignore cached file and fetch from API, by default ``False``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing OHLCV data sorted by time.
+    """
+    cache_file = RAW_DATA_DIR / f"{symbol}_{interval}_{limit}.csv"
+    if cache_file.exists() and not force_refresh:
+        return _load_cached(cache_file)
+
+    klines = get_klines(symbol, interval, limit)
+    df = _convert_to_dataframe(klines)
+    df.to_csv(cache_file, index=False)
+    return df
+
+
+def _load_cached(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    df["time"] = pd.to_datetime(df["time"])
+    return df
+
+
+def _convert_to_dataframe(rows: List[Dict[str, Any]]) -> pd.DataFrame:
+    df = pd.DataFrame(rows)
+    # Ensure correct dtypes
+    numeric_cols = [c for c in df.columns if c != "time"]
+    df[numeric_cols] = df[numeric_cols].astype(float)
+    df["time"] = pd.to_datetime(df["time"].astype(int), unit="ms")
+    df = df.sort_values("time").reset_index(drop=True)
+    return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.32.3
 websockets>=15.0.1
 PyYAML>=6.0
+pandas>=2.2

--- a/tests/test_market_data_collector.py
+++ b/tests/test_market_data_collector.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pandas as pd
+
+from data import market_data_collector as mdc
+
+
+def test_fetch_market_data(tmp_path, monkeypatch):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    monkeypatch.setattr(mdc, "RAW_DATA_DIR", raw_dir)
+    df = mdc.fetch_market_data("BTCUSDT", "1m", limit=1, force_refresh=True)
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert {"open", "high", "low", "close", "time"}.issubset(df.columns)
+    assert (raw_dir / "BTCUSDT_1m_1.csv").exists()


### PR DESCRIPTION
## Summary
- add market data collector and API client
- cache API results to disk
- add pandas requirement
- include tests for the collector

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68695cb60bfc832ab0792affc3b028eb