### PR TITLE
Implement risk arbitration and score persistence

### DIFF
--- a/ai/arbitration_engine.py
+++ b/ai/arbitration_engine.py
@@ -1,0 +1,42 @@
+import math
+from collections import defaultdict
+from typing import Iterable
+
+
+class ArbitrationEngine:
+    """Simple UCB1 based strategy arbitration engine."""
+
+    def __init__(self, decay: float = 0.99) -> None:
+        self.decay = decay
+        self.counts = defaultdict(int)
+        self.values = defaultdict(float)
+
+    # ------------------------------------------------------------------
+    def select_strategy(
+        self, symbol: str, timeframe: str, strategies: Iterable[str]
+    ) -> str:
+        """Return the strategy with highest UCB1 score."""
+        strategies = list(strategies)
+        # ensure each strategy tried once
+        for name in strategies:
+            if self.counts[name] == 0:
+                return name
+
+        total = sum(self.counts[s] for s in strategies)
+        ucb_scores = {}
+        for name in strategies:
+            avg_reward = self.values[name] / self.counts[name]
+            bonus = math.sqrt(2 * math.log(total) / self.counts[name])
+            ucb_scores[name] = avg_reward + bonus
+        return max(ucb_scores, key=ucb_scores.get)
+
+    def update_rewards(self, strategy_name: str, trade_result: float) -> None:
+        """Update reward statistics based on trade outcome."""
+        self.counts[strategy_name] += 1
+        self.values[strategy_name] += trade_result
+
+    def decay_scores(self) -> None:
+        """Apply exponential decay to older performance."""
+        for name in list(self.values.keys()):
+            self.values[name] *= self.decay
+            self.counts[name] = max(1, int(self.counts[name] * self.decay))

--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -1,0 +1,20 @@
+from backtest.backtester import Backtester
+from strategies.scalper import ScalperBot
+from storage.strategy_score_store import StrategyScoreStore
+
+
+def run() -> None:
+    strat = ScalperBot()
+    tester = Backtester(strat)
+    prices = [1, 2, 3, 2, 4, 5]
+    trades = tester.run(prices)
+
+    store = StrategyScoreStore()
+    for side, _ in trades:
+        result = 1.0 if side == "buy" else -1.0
+        store.update_score(strat.name, result)
+    store.save()
+
+
+if __name__ == "__main__":
+    run()

--- a/engine/ai_coordinator.py
+++ b/engine/ai_coordinator.py
@@ -5,6 +5,8 @@ from typing import Dict, Iterable, Any
 from strategies.base import BaseStrategy, Signal
 from strategies import load_strategy
 from .score_manager import ScoreManager
+from ai.arbitration_engine import ArbitrationEngine
+from storage.strategy_score_store import StrategyScoreStore
 
 
 class AICoordinator:
@@ -12,11 +14,17 @@ class AICoordinator:
 
     def __init__(self, strategy_configs: Dict[str, Dict[str, Any]], capital: float = 1.0) -> None:
         self.score_manager = ScoreManager()
+        self.score_store = StrategyScoreStore()
+        self.arbitration_engine = ArbitrationEngine()
         self.capital = capital
         self.strategies: Dict[str, BaseStrategy] = {}
         for name, cfg in strategy_configs.items():
             cls = load_strategy(cfg.pop("module"))
             self.strategies[name] = cls(**cfg)
+
+    def choose_strategy(self, symbol: str, timeframe: str) -> BaseStrategy:
+        name = self.arbitration_engine.select_strategy(symbol, timeframe, self.strategies.keys())
+        return self.strategies[name]
 
     def process(self, market_data: Dict[str, Any]) -> Dict[str, Signal]:
         signals: Dict[str, Signal] = {}
@@ -42,3 +50,10 @@ class AICoordinator:
                 score = self.score_manager.get_score(name)
                 allocations[name] = self.capital * (score / total_score) if total_score else 0.0
         return allocations
+
+    # ------------------------------------------------------------------
+    def update_performance(self, strategy_name: str, result: float) -> None:
+        """Update internal reward trackers."""
+        self.arbitration_engine.update_rewards(strategy_name, result)
+        self.score_store.update_score(strategy_name, result)
+        self.score_store.save()

--- a/services/strategy_manager_server.py
+++ b/services/strategy_manager_server.py
@@ -7,6 +7,8 @@ from typing import Dict, Any
 
 from services.grpc import strategy_manager_pb2, strategy_manager_pb2_grpc
 from engine.score_manager import ScoreManager
+from risk.risk_manager import RiskManager
+from storage.strategy_score_store import StrategyScoreStore
 
 
 class ExecutionRouter:
@@ -22,27 +24,27 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
         self.scores_file = scores_file
         self.log_file = log_file
         self.score_manager = ScoreManager()
+        self.score_store = StrategyScoreStore(scores_file)
         self.execution_router = ExecutionRouter()
+        self.risk_manager = RiskManager()
         self.risk_profiles = {
             "default": {"max_risk": 0.02, "preferred_timeframes": ["1m", "5m"]},
         }
         self.active_symbols: Dict[str, str] = {}
+        self.daily_loss = 0.0
         self._load_scores()
         self._log_writer = None
 
     # ------------------------------------------------------------------
     def _load_scores(self) -> None:
-        try:
-            with open(self.scores_file, "r") as f:
-                data = json.load(f)
-            for name, score in data.items():
-                self.score_manager.scores[name] = score
-        except FileNotFoundError:
-            pass
+        self.score_store.load()
+        for name, profile in self.score_store.scores.items():
+            self.score_manager.scores[name] = profile.get("avg_return", 0.0)
 
     def _save_scores(self) -> None:
-        with open(self.scores_file, "w") as f:
-            json.dump(self.score_manager.get_all(), f)
+        for name, value in self.score_manager.get_all().items():
+            self.score_store.update_score(name, value)
+        self.score_store.save()
 
     def _get_log_writer(self) -> csv.writer:
         if self._log_writer is None:
@@ -69,7 +71,14 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
         scores = self.score_manager.get_all()
         top_total = sum(scores.values())
         allocation = self.capital * (score / top_total) if top_total else 0.0
-        size = allocation / request.entry_price if request.entry_price else 0.0
+        volatility = abs(request.entry_price - request.sl) if request.sl else request.entry_price * 0.01
+        qty = self.risk_manager.compute_position_size(request.confidence, volatility, allocation)
+        leverage = self.risk_manager.adjust_leverage(name)
+        size = qty * leverage
+
+        # risk check: max drawdown
+        if not self.risk_manager.enforce_max_drawdown(self.daily_loss, None):
+            return strategy_manager_pb2.ExecutionResponse(message="drawdown limit")
 
         # basic safety: prevent duplicate orders per symbol
         last_side = self.active_symbols.get(request.symbol)
@@ -86,6 +95,7 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
             "tp": request.tp,
         }
         self.execution_router.execute(order)
+        self.daily_loss += -reward if reward < 0 else 0.0
 
         writer = self._get_log_writer()
         writer.writerow([
@@ -97,6 +107,7 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
             request.sl,
             request.tp,
         ])
+        self.score_store.update_score(name, reward)
         self._save_scores()
         exec_order = strategy_manager_pb2.ExecutionOrder(**order)
         return strategy_manager_pb2.ExecutionResponse(orders=[exec_order], message="ok")

--- a/storage/strategy_score_store.py
+++ b/storage/strategy_score_store.py
@@ -1,0 +1,52 @@
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+
+class StrategyScoreStore:
+    """Persist strategy performance statistics to JSON."""
+
+    def __init__(self, path: str = "strategy_scores.json") -> None:
+        self.path = Path(path)
+        self.scores: Dict[str, Dict[str, Any]] = {}
+        self.load()
+
+    # ------------------------------------------------------------------
+    def load(self) -> None:
+        try:
+            with open(self.path, "r") as f:
+                self.scores = json.load(f)
+        except FileNotFoundError:
+            self.scores = {}
+
+    def save(self) -> None:
+        with open(self.path, "w") as f:
+            json.dump(self.scores, f)
+
+    # ------------------------------------------------------------------
+    def get_score(self, strategy_name: str) -> Dict[str, Any] | None:
+        return self.scores.get(strategy_name)
+
+    def update_score(self, strategy_name: str, result: float) -> Dict[str, Any]:
+        profile = self.scores.get(
+            strategy_name,
+            {
+                "strategy_name": strategy_name,
+                "hit_rate": 0.0,
+                "avg_return": 0.0,
+                "recent_outcomes": [],
+                "last_updated": "",
+            },
+        )
+        outcomes = profile["recent_outcomes"]
+        outcomes.append(result)
+        if len(outcomes) > 100:
+            outcomes.pop(0)
+        wins = sum(1 for r in outcomes if r > 0)
+        profile["hit_rate"] = wins / len(outcomes)
+        profile["avg_return"] = sum(outcomes) / len(outcomes)
+        profile["recent_outcomes"] = outcomes
+        profile["last_updated"] = datetime.utcnow().isoformat()
+        self.scores[strategy_name] = profile
+        return profile


### PR DESCRIPTION
## Summary
- extend risk manager with position sizing, drawdown and leverage helpers
- add a UCB1-based arbitration engine
- persist strategy results with `StrategyScoreStore`
- integrate new components into AI coordinator and gRPC server
- include backtest runner to log scores

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686991f18204832a94b7e2ba0d97d56a