### PR TITLE
Standardized Signal objects

### DIFF
--- a/core/signal.py
+++ b/core/signal.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+import time
+
+@dataclass
+class Signal:
+    """Standard trading signal with metadata."""
+
+    action: str  # 'buy', 'sell' or 'hold'
+    confidence: float = 0.0
+    sl: Optional[float] = None
+    tp: Optional[float] = None
+    symbol: str = ""
+    timeframe: str = ""
+    timestamp: int = field(default_factory=lambda: int(time.time() * 1000))
+    strategy_name: str = ""

--- a/engine/ai_coordinator.py
+++ b/engine/ai_coordinator.py
@@ -25,7 +25,13 @@ class AICoordinator:
             if data is None:
                 continue
             sig = strat.generate_signal(data)
-            signals[name] = sig if isinstance(sig, Signal) else Signal(str(sig))
+            if isinstance(sig, Signal):
+                signals[name] = sig
+            else:
+                signals[name] = strat._signal(action=str(sig))
+            print(
+                f"Generated signal {signals[name].action} ({signals[name].confidence:.2f}) for {signals[name].symbol} via {signals[name].strategy_name}"
+            )
         return signals
 
     def allocate(self, signals: Dict[str, Signal]) -> Dict[str, float]:

--- a/services/strategy_manager_server.py
+++ b/services/strategy_manager_server.py
@@ -7,6 +7,7 @@ from typing import Dict, Any
 
 from services.grpc import strategy_manager_pb2, strategy_manager_pb2_grpc
 from engine.score_manager import ScoreManager
+from core.signal import Signal
 
 
 class ExecutionRouter:
@@ -29,6 +30,33 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
         self.active_symbols: Dict[str, str] = {}
         self._load_scores()
         self._log_writer = None
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _pb_to_signal(msg: strategy_manager_pb2.SignalMessage) -> Signal:
+        return Signal(
+            action=msg.signal_type,
+            confidence=msg.confidence,
+            sl=msg.sl if msg.sl else None,
+            tp=msg.tp if msg.tp else None,
+            symbol=msg.symbol,
+            timeframe=msg.timeframe,
+            timestamp=int(datetime.utcnow().timestamp() * 1000),
+            strategy_name=msg.strategy_name,
+        )
+
+    @staticmethod
+    def _signal_to_pb(signal: Signal, entry_price: float = 0.0) -> strategy_manager_pb2.SignalMessage:
+        return strategy_manager_pb2.SignalMessage(
+            strategy_name=signal.strategy_name,
+            symbol=signal.symbol,
+            timeframe=signal.timeframe,
+            signal_type=signal.action,
+            confidence=signal.confidence,
+            entry_price=entry_price,
+            sl=signal.sl or 0.0,
+            tp=signal.tp or 0.0,
+        )
 
     # ------------------------------------------------------------------
     def _load_scores(self) -> None:
@@ -60,10 +88,14 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
 
     # ------------------------------------------------------------------
     def SendSignal(self, request: strategy_manager_pb2.SignalMessage, context: grpc.ServicerContext) -> strategy_manager_pb2.ExecutionResponse:
-        name = request.strategy_name
+        sig = self._pb_to_signal(request)
+        print(
+            f"Received {sig.strategy_name} signal {sig.action} ({sig.confidence:.2f}) for {sig.symbol}"
+        )
+        name = sig.strategy_name
         profile = self.risk_profiles.get(name, self.risk_profiles["default"])
-        regime_match = 1.0 if request.timeframe in profile.get("preferred_timeframes", []) else 0.5
-        reward = request.confidence * regime_match
+        regime_match = 1.0 if sig.timeframe in profile.get("preferred_timeframes", []) else 0.5
+        reward = sig.confidence * regime_match
         score = self.score_manager.update_score(name, reward)
 
         scores = self.score_manager.get_all()
@@ -72,18 +104,18 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
         size = allocation / request.entry_price if request.entry_price else 0.0
 
         # basic safety: prevent duplicate orders per symbol
-        last_side = self.active_symbols.get(request.symbol)
-        if last_side and last_side == request.signal_type:
+        last_side = self.active_symbols.get(sig.symbol)
+        if last_side and last_side == sig.action:
             message = "duplicate signal ignored"
             return strategy_manager_pb2.ExecutionResponse(message=message)
-        self.active_symbols[request.symbol] = request.signal_type
+        self.active_symbols[sig.symbol] = sig.action
 
         order = {
-            "symbol": request.symbol,
-            "side": request.signal_type,
+            "symbol": sig.symbol,
+            "side": sig.action,
             "size": size,
-            "sl": request.sl,
-            "tp": request.tp,
+            "sl": sig.sl,
+            "tp": sig.tp,
         }
         self.execution_router.execute(order)
 
@@ -91,11 +123,11 @@ class StrategyManager(strategy_manager_pb2_grpc.StrategyManagerServicer):
         writer.writerow([
             datetime.utcnow().isoformat(),
             name,
-            request.symbol,
-            request.signal_type,
+            sig.symbol,
+            sig.action,
             f"{size:.6f}",
-            request.sl,
-            request.tp,
+            sig.sl,
+            sig.tp,
         ])
         self._save_scores()
         exec_order = strategy_manager_pb2.ExecutionOrder(**order)

--- a/strategies/arbitrage.py
+++ b/strategies/arbitrage.py
@@ -20,11 +20,11 @@ class ArbitrageBot(BaseStrategy):
 
     def generate_signal(self, prices: Dict[str, float]) -> Signal:
         if not prices:
-            return Signal("hold")
+            return self._signal("hold")
         max_ex = max(prices, key=prices.get)
         min_ex = min(prices, key=prices.get)
         spread = prices[max_ex] - prices[min_ex]
         if spread / prices[min_ex] > self.threshold:
             confidence = min(1.0, spread / prices[min_ex])
-            return Signal("buy", confidence)
-        return Signal("hold")
+            return self._signal("buy", confidence)
+        return self._signal("hold")

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -1,17 +1,8 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Optional
-
-
-@dataclass
-class Signal:
-    """Standard representation for strategy signals."""
-
-    action: str  # 'buy', 'sell' or 'hold'
-    confidence: float = 0.0
-    sl: Optional[float] = None
-    tp: Optional[float] = None
+from core.signal import Signal
+import time
 
 
 class BaseStrategy:
@@ -22,6 +13,25 @@ class BaseStrategy:
         self.symbol = symbol
         self.timeframe = timeframe
         self.risk_pct = risk_pct
+
+    # --------------------------------------------------------------
+    def _signal(
+        self,
+        action: str = "hold",
+        confidence: float = 0.0,
+        sl: Optional[float] = None,
+        tp: Optional[float] = None,
+    ) -> Signal:
+        return Signal(
+            action=action,
+            confidence=confidence,
+            sl=sl,
+            tp=tp,
+            symbol=self.symbol,
+            timeframe=self.timeframe,
+            timestamp=int(time.time() * 1000),
+            strategy_name=self.name,
+        )
 
     def on_data(self, price: float) -> None:
         """Receive new price data."""

--- a/strategies/breakout.py
+++ b/strategies/breakout.py
@@ -29,14 +29,14 @@ class BreakoutBot(BaseStrategy):
             for _, candle in df.tail(1).iterrows():
                 self.on_data(candle.to_dict())
         if len(self.highs) < self.window:
-            return Signal("hold")
+            return self._signal("hold")
         avg_vol = sum(self.volumes) / len(self.volumes)
         prev_high = max(list(self.highs)[:-1])
         prev_low = min(list(self.lows)[:-1])
         if self.close is None:
-            return Signal("hold")
+            return self._signal("hold")
         if self.close > prev_high and self.volumes[-1] > avg_vol * self.vol_mult:
-            return Signal("buy", 0.5)
+            return self._signal("buy", 0.5)
         if self.close < prev_low and self.volumes[-1] > avg_vol * self.vol_mult:
-            return Signal("sell", 0.5)
-        return Signal("hold")
+            return self._signal("sell", 0.5)
+        return self._signal("hold")

--- a/strategies/dca_investment.py
+++ b/strategies/dca_investment.py
@@ -24,5 +24,5 @@ class DCAInvestmentBot(BaseStrategy):
         now = df.index[-1] if isinstance(df.index[-1], datetime) else datetime.utcnow()
         if self.last_buy is None or now - self.last_buy >= self.interval:
             self.last_buy = now
-            return Signal("buy", 0.3)
-        return Signal("hold")
+            return self._signal("buy", 0.3)
+        return self._signal("hold")

--- a/strategies/ema_crossover.py
+++ b/strategies/ema_crossover.py
@@ -1,7 +1,7 @@
 from collections import deque
 from typing import Deque
 
-from .base import BaseStrategy
+from .base import BaseStrategy, Signal
 from utils.indicators import ema
 
 
@@ -23,11 +23,11 @@ class EMACrossoverStrategy(BaseStrategy):
             self.fast_ema = ema(price_list, self.fast)
             self.slow_ema = ema(price_list, self.slow)
 
-    def generate_signal(self) -> str:
+    def generate_signal(self) -> Signal:
         if self.fast_ema is None or self.slow_ema is None:
-            return "hold"
+            return self._signal("hold")
         if self.fast_ema > self.slow_ema:
-            return "buy"
+            return self._signal("buy")
         if self.fast_ema < self.slow_ema:
-            return "sell"
-        return "hold"
+            return self._signal("sell")
+        return self._signal("hold")

--- a/strategies/grid.py
+++ b/strategies/grid.py
@@ -22,19 +22,19 @@ class GridBot(BaseStrategy):
 
     def generate_signal(self, df: pd.DataFrame) -> Signal:
         if len(df) < 15:
-            return Signal("hold")
+            return self._signal("hold")
         atr_val = atr(df["high"].tolist(), df["low"].tolist(), df["close"].tolist(), 14)
         if atr_val is None:
-            return Signal("hold")
+            return self._signal("hold")
         price = df["close"].iloc[-1]
         grid_size = atr_val * self.grid_mult
         if self.last_level is None:
             self.last_level = price
-            return Signal("hold")
+            return self._signal("hold")
         if price >= self.last_level + grid_size:
             self.last_level = price
-            return Signal("sell", 0.5)
+            return self._signal("sell", 0.5)
         if price <= self.last_level - grid_size:
             self.last_level = price
-            return Signal("buy", 0.5)
-        return Signal("hold")
+            return self._signal("buy", 0.5)
+        return self._signal("hold")

--- a/strategies/liquidity_sweep.py
+++ b/strategies/liquidity_sweep.py
@@ -13,7 +13,7 @@ class LiquiditySweepBot(BaseStrategy):
 
     def generate_signal(self, df: pd.DataFrame) -> Signal:
         if len(df) < 5:
-            return Signal("hold")
+            return self._signal("hold")
         highs = df["high"]
         lows = df["low"]
         recent_high = highs.iloc[-1]
@@ -21,7 +21,7 @@ class LiquiditySweepBot(BaseStrategy):
         prev_high = highs.iloc[-5:-1].max()
         prev_low = lows.iloc[-5:-1].min()
         if recent_high > prev_high:
-            return Signal("sell", 0.4)
+            return self._signal("sell", 0.4)
         if recent_low < prev_low:
-            return Signal("buy", 0.4)
-        return Signal("hold")
+            return self._signal("buy", 0.4)
+        return self._signal("hold")

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -3,7 +3,7 @@
 from collections import deque
 from typing import Deque
 
-from .base import BaseStrategy
+from .base import BaseStrategy, Signal
 from utils.indicators import simple_moving_average
 
 
@@ -19,16 +19,16 @@ class MeanReversionStrategy(BaseStrategy):
     def on_data(self, price: float) -> None:  # type: ignore[override]
         self.prices.append(price)
 
-    def generate_signal(self) -> str:  # type: ignore[override]
+    def generate_signal(self) -> Signal:  # type: ignore[override]
         if len(self.prices) < self.window:
-            return "hold"
+            return self._signal("hold")
         sma = simple_moving_average(list(self.prices), self.window)
         if sma is None:
-            return "hold"
+            return self._signal("hold")
         last_price = self.prices[-1]
         if last_price < sma * (1 - self.threshold):
-            return "buy"
+            return self._signal("buy")
         if last_price > sma * (1 + self.threshold):
-            return "sell"
-        return "hold"
+            return self._signal("sell")
+        return self._signal("hold")
 

--- a/strategies/mean_reversion_bot.py
+++ b/strategies/mean_reversion_bot.py
@@ -14,7 +14,7 @@ class MeanReversionBot(BaseStrategy):
 
     def generate_signal(self, df: pd.DataFrame) -> Signal:
         if len(df) < self.window + 1:
-            return Signal("hold")
+            return self._signal("hold")
         close = df["close"]
         mean = close.rolling(self.window).mean().iloc[-1]
         std = close.rolling(self.window).std().iloc[-1]
@@ -24,7 +24,7 @@ class MeanReversionBot(BaseStrategy):
         vol = df["volume"].iloc[-1]
         price = close.iloc[-1]
         if price < lower and vol > vol_mean:
-            return Signal("buy", 0.5)
+            return self._signal("buy", 0.5)
         if price > upper and vol > vol_mean:
-            return Signal("sell", 0.5)
-        return Signal("hold")
+            return self._signal("sell", 0.5)
+        return self._signal("hold")

--- a/strategies/news_sentiment.py
+++ b/strategies/news_sentiment.py
@@ -19,13 +19,13 @@ class NewsSentimentBot(BaseStrategy):
 
     def generate_signal(self, texts: Iterable[str]) -> Signal:
         if not _sentiment or not texts:
-            return Signal("hold")
+            return self._signal("hold")
         joined = "\n".join(texts)
         result = _sentiment(joined[:512])[0]
         label = result.get("label", "neutral").lower()
         score = float(result.get("score", 0))
         if label == "positive" and score > 0.6:
-            return Signal("buy", score)
+            return self._signal("buy", score)
         if label == "negative" and score > 0.6:
-            return Signal("sell", score)
-        return Signal("hold")
+            return self._signal("sell", score)
+        return self._signal("hold")

--- a/strategies/options_hedger.py
+++ b/strategies/options_hedger.py
@@ -21,19 +21,19 @@ class OptionsHedgerBot(BaseStrategy):
 
     def generate_signal(self, data: dict) -> Signal:
         if not implied_volatility or not delta:
-            return Signal("hold")
+            return self._signal("hold")
         spot = data.get("spot")
         option_price = data.get("option_price")
         strike = data.get("strike")
         t = data.get("t", 0.0)
         r = data.get("r", 0.0)
         if not all(v is not None for v in [spot, option_price, strike]):
-            return Signal("hold")
+            return self._signal("hold")
         try:
             iv = implied_volatility(option_price, spot, strike, t, r, "c")
             d = delta("c", spot, strike, t, r, iv)
         except Exception:
-            return Signal("hold")
+            return self._signal("hold")
         if abs(d) > 0.5:
-            return Signal("buy" if d > 0 else "sell", min(1.0, abs(d)))
-        return Signal("hold")
+            return self._signal("buy" if d > 0 else "sell", min(1.0, abs(d)))
+        return self._signal("hold")

--- a/strategies/scalper.py
+++ b/strategies/scalper.py
@@ -43,15 +43,15 @@ class ScalperBot(BaseStrategy):
 
     def generate_signal(self, df: pd.DataFrame) -> Signal:
         if df.empty or len(df) < self.slow + 1:
-            return Signal("hold")
+            return self._signal("hold")
         ema_fast = df["close"].ewm(span=self.fast, adjust=False).mean().iloc[-1]
         ema_slow = df["close"].ewm(span=self.slow, adjust=False).mean().iloc[-1]
         vol = self._volatility(df)
         if vol is None or vol > self.vol_threshold:
-            return Signal("hold")
+            return self._signal("hold")
         sl, tp = self._atr_levels(df)
         if ema_fast > ema_slow:
-            return Signal("buy", 0.7, sl, tp)
+            return self._signal("buy", 0.7, sl, tp)
         if ema_fast < ema_slow:
-            return Signal("sell", 0.7, sl, tp)
-        return Signal("hold")
+            return self._signal("sell", 0.7, sl, tp)
+        return self._signal("hold")

--- a/strategies/swing.py
+++ b/strategies/swing.py
@@ -24,24 +24,24 @@ class SwingBot(BaseStrategy):
 
     def generate_signal(self, df: pd.DataFrame) -> Signal:
         if len(df) < max(self.ema_fast, self.sma_slow) + 2:
-            return Signal("hold")
+            return self._signal("hold")
         ema_fast = df["close"].ewm(span=self.ema_fast, adjust=False).mean().iloc[-1]
         sma_slow = df["close"].rolling(self.sma_slow).mean().iloc[-1]
         macd_val = macd(df["close"].tolist())
         rsi_val = rsi(df["close"].tolist())
         if not macd_val or rsi_val is None:
-            return Signal("hold")
+            return self._signal("hold")
         macd_line, macd_signal = macd_val
         if (
             ema_fast > sma_slow
             and macd_line > macd_signal
             and rsi_val < 70
         ):
-            return Signal("buy", 0.6)
+            return self._signal("buy", 0.6)
         if (
             ema_fast < sma_slow
             and macd_line < macd_signal
             and rsi_val > 30
         ):
-            return Signal("sell", 0.6)
-        return Signal("hold")
+            return self._signal("sell", 0.6)
+        return self._signal("hold")


### PR DESCRIPTION
## Summary
- add shared `core/Signal` dataclass with metadata
- update BaseStrategy with helper to create signals
- refactor all strategies to return full Signal objects
- map gRPC SignalMessage to/from Signal in server
- log generated signals in AI coordinator and gRPC server

## Testing
- `pip install pandas==2.3.0 requests ccxt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686992c8db08832aa08ff1995abdd7d6