### PR TITLE
Add strategy templates and dynamic backtest discovery

### DIFF
--- a/backtest/run_backtest.py
+++ b/backtest/run_backtest.py
@@ -1,21 +1,68 @@
-from backtest.backtester import Backtester
-from strategies.scalper import ScalperBot
-from storage.strategy_score_store import StrategyScoreStore
+import os
+import importlib
+import inspect
+import logging
+
+
+from strategies.base import BaseStrategy
+from backtest.data_loader import CSVDataLoader
+from backtest.engine import BacktestEngine
+
+logging.basicConfig(level=logging.INFO)
+
+
+def _discover_strategy_classes() -> list[type[BaseStrategy]]:
+    classes: list[type[BaseStrategy]] = []
+    for file in os.listdir("strategies"):
+        if not file.endswith(".py"):
+            continue
+        name = file[:-3]
+        if name in {"__init__", "base"}:
+            continue
+        module = importlib.import_module(f"strategies.{name}")
+        for attr in dir(module):
+            obj = getattr(module, attr)
+            if inspect.isclass(obj) and issubclass(obj, BaseStrategy) and obj is not BaseStrategy:
+                classes.append(obj)
+                break
+    return classes
+
+
+def _instantiate_strategies(data: dict) -> list[BaseStrategy]:
+    strategies: list[BaseStrategy] = []
+    for cls in _discover_strategy_classes():
+        sig = inspect.signature(cls.__init__)
+        for (symbol, timeframe) in data.keys():
+            kwargs = {}
+            if "symbol" in sig.parameters:
+                kwargs["symbol"] = symbol
+            if "timeframe" in sig.parameters:
+                kwargs["timeframe"] = timeframe
+            try:
+                strategies.append(cls(**kwargs))
+            except Exception as exc:  # pragma: no cover - ignore bad init
+                logging.warning("Could not instantiate %s: %s", cls.__name__, exc)
+    return strategies
 
 
 def run() -> None:
-    strat = ScalperBot()
-    tester = Backtester(strat)
-    prices = [1, 2, 3, 2, 4, 5]
-    trades = tester.run(prices)
-
-    store = StrategyScoreStore()
-    for side, _ in trades:
-        result = 1.0 if side == "buy" else -1.0
-        store.update_score(strat.name, result)
-    store.save()
+    loader = CSVDataLoader()
+    data = loader.load()
+    strategies = _instantiate_strategies(data)
+    engine = BacktestEngine(data, strategies)
+    engine.run()
+    for trade in engine.trade_log:
+        logging.info(
+            "%s triggered %s on %s %s",
+            trade.strategy,
+            trade.side,
+            trade.symbol,
+            trade.entry_time,
+        )
+    engine.save_trade_log()
+    summary = engine.summary()
+    logging.info("Backtest summary: %s", summary)
 
 
 if __name__ == "__main__":
     run()
-

--- a/strategies/arbitrage.py
+++ b/strategies/arbitrage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Dict
+import pandas as pd
 
 from .base import BaseStrategy, Signal
 
@@ -18,13 +19,14 @@ class ArbitrageBot(BaseStrategy):
         super().__init__("ArbitrageBot", symbol, timeframe, risk_pct)
         self.threshold = threshold
 
-    def generate_signal(self, prices: Dict[str, float]) -> Signal:
-        if not prices:
+    def generate_signal(self, df: pd.DataFrame) -> Signal:
+        if df.empty:
             return self._signal("hold")
+        prices: Dict[str, float] = df.iloc[-1].to_dict()
         max_ex = max(prices, key=prices.get)
         min_ex = min(prices, key=prices.get)
         spread = prices[max_ex] - prices[min_ex]
-        if spread / prices[min_ex] > self.threshold:
+        if prices[min_ex] and spread / prices[min_ex] > self.threshold:
             confidence = min(1.0, spread / prices[min_ex])
             return self._signal("buy", confidence)
         return self._signal("hold")

--- a/strategies/breakout.py
+++ b/strategies/breakout.py
@@ -24,10 +24,9 @@ class BreakoutBot(BaseStrategy):
         self.volumes.append(candle["volume"])
         self.close = candle["close"]
 
-    def generate_signal(self, df: pd.DataFrame | None = None) -> Signal:
-        if df is not None:
-            for _, candle in df.tail(1).iterrows():
-                self.on_data(candle.to_dict())
+    def generate_signal(self, df: pd.DataFrame) -> Signal:
+        for _, candle in df.tail(1).iterrows():
+            self.on_data(candle.to_dict())
         if len(self.highs) < self.window:
             return self._signal("hold")
         avg_vol = sum(self.volumes) / len(self.volumes)

--- a/strategies/news_sentiment.py
+++ b/strategies/news_sentiment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable
+import pandas as pd
 
 from .base import BaseStrategy, Signal
 
@@ -17,9 +18,10 @@ class NewsSentimentBot(BaseStrategy):
     def __init__(self, symbol: str, timeframe: str = "1h", risk_pct: float = 0.01) -> None:
         super().__init__("NewsSentimentBot", symbol, timeframe, risk_pct)
 
-    def generate_signal(self, texts: Iterable[str]) -> Signal:
-        if not _sentiment or not texts:
+    def generate_signal(self, df: pd.DataFrame) -> Signal:
+        if not _sentiment or df.empty or "text" not in df.columns:
             return self._signal("hold")
+        texts: Iterable[str] = df["text"].astype(str).tolist()
         joined = "\n".join(texts)
         result = _sentiment(joined[:512])[0]
         label = result.get("label", "neutral").lower()

--- a/strategies/options_hedger.py
+++ b/strategies/options_hedger.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from typing import Optional
+import pandas as pd
 
 from .base import BaseStrategy, Signal
 
@@ -19,14 +20,15 @@ class OptionsHedgerBot(BaseStrategy):
     def __init__(self, symbol: str, timeframe: str = "1h", risk_pct: float = 0.02) -> None:
         super().__init__("OptionsHedgerBot", symbol, timeframe, risk_pct)
 
-    def generate_signal(self, data: dict) -> Signal:
-        if not implied_volatility or not delta:
+    def generate_signal(self, df: pd.DataFrame) -> Signal:
+        if not implied_volatility or not delta or df.empty:
             return self._signal("hold")
-        spot = data.get("spot")
-        option_price = data.get("option_price")
-        strike = data.get("strike")
-        t = data.get("t", 0.0)
-        r = data.get("r", 0.0)
+        row = df.iloc[-1]
+        spot = row.get("spot")
+        option_price = row.get("option_price")
+        strike = row.get("strike")
+        t = row.get("t", 0.0)
+        r = row.get("r", 0.0)
         if not all(v is not None for v in [spot, option_price, strike]):
             return self._signal("hold")
         try:


### PR DESCRIPTION
## Summary
- create uniform `generate_signal(df)` implementations for advanced strategy bots
- add automatic strategy discovery and logging in the backtest runner

## Testing
- `PYTHONPATH=. pytest tests/test_strategy_loader.py -q`
- `PYTHONPATH=. pytest -q` *(fails: No module named 'ccxt')*

------
https://chatgpt.com/codex/tasks/task_e_686999ec2e84832aacdd2e699ecd7663